### PR TITLE
Feat: add methods for turn counter and pick column

### DIFF
--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -1,12 +1,14 @@
 require 'pry'
 require './player'
+require './column'
 #other requires go here
 
 class Turn
-  attr_reader :player_type, :column_choice
+  attr_reader :player_type, :column_choice, :counter
   def initialize(player_type)
       @player_type = player_type
       @column_choice = column_choice
+      @counter = 0
   end
 
   # def user_turn
@@ -24,13 +26,20 @@ class Turn
   # end #this can be passed to the column class to run .playable?
 
   def user_turn
+    @counter += 1
     if @player_type == :human
       puts "Please select a column:"
         column_choice = gets.chomp
       else
+        @counter += 1
         puts "It's the robot's turn!"
         column_choice = (["A ","B ","C ","D ","E ","F ","G "]).sample
       end
+    end
+
+    def pick_column
+      player_column_choice = user_turn
+      return player_column_choice
     end
 
 end

--- a/spec/column_spec.rb
+++ b/spec/column_spec.rb
@@ -1,5 +1,7 @@
 require 'rspec'
 require 'pry'
+require './lib/player'
+require './lib/turn'
 require './lib/board'
 require './lib/column'
 
@@ -30,7 +32,7 @@ RSpec.describe Column do
     board.add_x(5,0)
     #column
     a = Column.new(board.matrix.transpose[0])
-    binding.pry
+    #binding.pry
 
     expect(a.playable?).to eq(false)
 

--- a/spec/turn_spec.rb
+++ b/spec/turn_spec.rb
@@ -11,11 +11,24 @@ RSpec.describe Turn do
     expect(turn_1).to be_an_instance_of(Turn)
   end
 
+  it "starts at turn 0" do
+    player1 = Player.new("human")
+    turn_1 = Turn.new(:human)
+    expect(turn_1.counter).to eq(0)
+  end
+
   it "can perform a human turn" do
     player1 = Player.new("human")
     turn_1 = Turn.new(:human)
     turn_1.stub(:gets).and_return("A")
     expect(turn_1.user_turn).to eq("A")
+  end
+
+  it "the turn counter increases by one at the start of a human turn" do
+    player1 = Player.new("human")
+    turn_1 = Turn.new(:human)
+    turn_1.user_turn
+    expect(turn_1.counter).to eq(1)
   end
 
   it "can perform a robot turn" do
@@ -24,5 +37,32 @@ RSpec.describe Turn do
     turn_2.stub(:select).and_return("B")
     allow(turn_2.user_turn).to receive("B")
   end #this test actually passes. Here's where I found it:
-end   # https://gist.github.com/Kotauror/6993000de0c53206a96879515438950d
+  # https://gist.github.com/Kotauror/6993000de0c53206a96879515438950d
       # down toward the bottom, a post from ZASMan on April 30, 2021.
+  it "the turn counter increases by one at the start of a robot turn" do
+    player1 = Player.new("human")
+    turn_1 = Turn.new(:human)
+    player2 = Player.new("robot")
+    turn_2 = Turn.new(:robot)
+    turn_1.user_turn
+    turn_2.user_turn
+    expect(turn_2.counter).to eq(2)
+  end
+
+  it "detects the column choice of a human player" do
+    player1 = Player.new("human")
+    turn_1 = Turn.new(:human)
+    turn_1.user_turn
+    turn_1.stub(:gets).and_return("A")
+    turn_1.pick_column
+    expect(turn_1.pick_column).to eq("A")
+  end
+
+  it "detects the column choice of a robot player" do
+    player2 = Player.new("robot")
+    turn_2 = Turn.new(:robot)
+    turn_2.stub(:select).and_return("B")
+    allow(turn_2.user_turn).to receive("B")
+    allow(turn_2.pick_column).to receive("B")
+  end
+end


### PR DESCRIPTION
turn counter goes up by one each for human and robot. pick column method registers the user input and puts it in a variable called player column choice that can be passed to the column class to start the is valid? method.